### PR TITLE
Add reconnecting ptys

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <strong style="font-size: 1.5em; text-decoration: underline;">w</strong>eb <strong style="font-size: 1.5em;text-decoration: underline;">s</strong>ocket command <strong style="font-size: 1.5em;text-decoration: underline;">e</strong>xecution <strong style="font-size: 1.5em;text-decoration: underline;">p</strong>rotocol. It can be thought of as SSH without encryption.
 
 It's useful in cases where you want to provide a command exec interface into a remote environment. It's implemented
-with WebSocket so it may be used directly by a browser frontend. Its symmetric design satisfies 
+with WebSocket so it may be used directly by a browser frontend. Its symmetric design satisfies
 `wsep.Execer` for local and remote execution.
 
 ## Examples
@@ -54,8 +54,8 @@ go run ./dev/server
 Start a client:
 
 ```sh
-go run ./dev/client tty bash
-go run ./dev/client notty ls
+go run ./dev/client tty --id 1 -- bash
+go run ./dev/client notty -- ls -la
 ```
 
 ### Local performance cost
@@ -63,10 +63,10 @@ go run ./dev/client notty ls
 Local `sh` through a local `wsep` connection
 
 ```shell script
-$ head -c 100000000 /dev/urandom > /tmp/random; cat /tmp/random | pv | time ./bin/client notty sh -c "cat > /dev/null"
+$ head -c 100000000 /dev/urandom > /tmp/random; cat /tmp/random | pv | time ./bin/client notty -- sh -c "cat > /dev/null"
 
 95.4MiB 0:00:00 [ 269MiB/s] [ <=>                                                                                  ]
-./bin/client notty sh -c "cat > /dev/null"  0.32s user 0.31s system 31% cpu 2.019 total
+./bin/client notty -- sh -c "cat > /dev/null"  0.32s user 0.31s system 31% cpu 2.019 total
 ```
 
 Local `sh` directly

--- a/ci/image/Dockerfile
+++ b/ci/image/Dockerfile
@@ -3,6 +3,6 @@ FROM golang:1
 ENV GOFLAGS="-mod=readonly"
 ENV CI=true
 
-RUN go get golang.org/x/tools/cmd/goimports
-RUN go get golang.org/x/lint/golint
-RUN go get github.com/mattn/goveralls
+RUN go install golang.org/x/tools/cmd/goimports@latest
+RUN go install golang.org/x/lint/golint@latest
+RUN go install github.com/mattn/goveralls@latest

--- a/client.go
+++ b/client.go
@@ -27,6 +27,8 @@ func RemoteExecer(conn *websocket.Conn) Execer {
 
 // Command represents an external command to be run
 type Command struct {
+	// ID allows reconnecting commands that have a TTY.
+	ID         string
 	Command    string
 	Args       []string
 	TTY        bool
@@ -39,6 +41,7 @@ type Command struct {
 
 func (r remoteExec) Start(ctx context.Context, c Command) (Process, error) {
 	header := proto.ClientStartHeader{
+		ID:      c.ID,
 		Command: mapToProtoCmd(c),
 		Type:    proto.TypeStart,
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -56,7 +56,7 @@ func mockConn(ctx context.Context, t *testing.T) (*websocket.Conn, *httptest.Ser
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		err = Serve(r.Context(), ws, LocalExecer{})
+		err = Serve(r.Context(), ws, LocalExecer{}, nil)
 		if err != nil {
 			t.Errorf("failed to serve execer: %v", err)
 			ws.Close(websocket.StatusAbnormalClosure, "failed to serve execer")

--- a/client_test.go
+++ b/client_test.go
@@ -49,14 +49,14 @@ func TestRemoteStdin(t *testing.T) {
 	}
 }
 
-func mockConn(ctx context.Context, t *testing.T) (*websocket.Conn, *httptest.Server) {
+func mockConn(ctx context.Context, t *testing.T, options *Options) (*websocket.Conn, *httptest.Server) {
 	mockServerHandler := func(w http.ResponseWriter, r *http.Request) {
 		ws, err := websocket.Accept(w, r, nil)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		err = Serve(r.Context(), ws, LocalExecer{}, nil)
+		err = Serve(r.Context(), ws, LocalExecer{}, options)
 		if err != nil {
 			t.Errorf("failed to serve execer: %v", err)
 			ws.Close(websocket.StatusAbnormalClosure, "failed to serve execer")
@@ -77,7 +77,7 @@ func TestRemoteExec(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	ws, server := mockConn(ctx, t)
+	ws, server := mockConn(ctx, t, nil)
 	defer server.Close()
 
 	execer := RemoteExecer(ws)
@@ -89,7 +89,7 @@ func TestRemoteExecFail(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	ws, server := mockConn(ctx, t)
+	ws, server := mockConn(ctx, t, nil)
 	defer server.Close()
 
 	execer := RemoteExecer(ws)
@@ -123,7 +123,7 @@ func TestStderrVsStdout(t *testing.T) {
 		stderr bytes.Buffer
 	)
 
-	ws, server := mockConn(ctx, t)
+	ws, server := mockConn(ctx, t, nil)
 	defer server.Close()
 
 	execer := RemoteExecer(ws)

--- a/dev/client/main.go
+++ b/dev/client/main.go
@@ -23,35 +23,38 @@ type notty struct {
 }
 
 func (c *notty) Run(fl *pflag.FlagSet) {
-	do(fl, false)
+	do(fl, false, "")
 }
 
 func (c *notty) Spec() cli.CommandSpec {
 	return cli.CommandSpec{
-		Name:    "notty",
-		Usage:   "[flags]",
-		Desc:    `Run a command without tty enabled.`,
-		RawArgs: true,
+		Name:  "notty",
+		Usage: "[flags]",
+		Desc:  `Run a command without tty enabled.`,
 	}
 }
 
 type tty struct {
+	id string
 }
 
 func (c *tty) Run(fl *pflag.FlagSet) {
-	do(fl, true)
+	do(fl, true, c.id)
 }
 
 func (c *tty) Spec() cli.CommandSpec {
 	return cli.CommandSpec{
-		Name:    "tty",
-		Usage:   "[flags]",
-		Desc:    `Run a command with tty enabled.`,
-		RawArgs: true,
+		Name:  "tty",
+		Usage: "[id] [flags]",
+		Desc:  `Run a command with tty enabled.  Use the same ID to reconnect.`,
 	}
 }
 
-func do(fl *pflag.FlagSet, tty bool) {
+func (c *tty) RegisterFlags(fl *pflag.FlagSet) {
+	fl.StringVar(&c.id, "id", "", "sets id for reconnection")
+}
+
+func do(fl *pflag.FlagSet, tty bool, id string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -71,6 +74,7 @@ func do(fl *pflag.FlagSet, tty bool) {
 		args = fl.Args()[1:]
 	}
 	process, err := executor.Start(ctx, wsep.Command{
+		ID:      id,
 		Command: fl.Arg(0),
 		Args:    args,
 		TTY:     tty,

--- a/dev/server/main.go
+++ b/dev/server/main.go
@@ -23,7 +23,7 @@ func serve(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	err = wsep.Serve(r.Context(), ws, wsep.LocalExecer{})
+	err = wsep.Serve(r.Context(), ws, wsep.LocalExecer{}, nil)
 	if err != nil {
 		flog.Error("failed to serve execer: %v", err)
 		ws.Close(websocket.StatusAbnormalClosure, "failed to serve execer")

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.14
 
 require (
 	cdr.dev/slog v1.3.0
+	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/creack/pty v1.1.11
 	github.com/google/go-cmp v0.4.0
 	github.com/google/uuid v1.3.0
-	github.com/smallnest/ringbuffer v0.0.0-20210227121335-0a58434b36f2
 	github.com/spf13/pflag v1.0.5
 	go.coder.com/cli v0.4.0
 	go.coder.com/flog v0.0.0-20190906214207-47dd47ea0512

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	cdr.dev/slog v1.3.0
 	github.com/creack/pty v1.1.11
 	github.com/google/go-cmp v0.4.0
+	github.com/google/uuid v1.3.0
+	github.com/smallnest/ringbuffer v0.0.0-20210227121335-0a58434b36f2
 	github.com/spf13/pflag v1.0.5
 	go.coder.com/cli v0.4.0
 	go.coder.com/flog v0.0.0-20190906214207-47dd47ea0512

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/alecthomas/kong v0.2.1-0.20190708041108-0548c6b1afae/go.mod h1:+inYUS
 github.com/alecthomas/kong-hcl v0.1.8-0.20190615233001-b21fea9723c8/go.mod h1:MRgZdU3vrFd05IQ89AxUZ0aYdF39BYoNFa324SodPCA=
 github.com/alecthomas/repr v0.0.0-20180818092828-117648cd9897 h1:p9Sln00KOTlrYkxI1zYWl1QLnEqAqEARBEYa8FQnQcY=
 github.com/alecthomas/repr v0.0.0-20180818092828-117648cd9897/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
+github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 h1:7Ip0wMmLHLRJdrloDxZfhMm0xrLXZS8+COSu2bXmEQs=
+github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
@@ -141,8 +143,6 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/smallnest/ringbuffer v0.0.0-20210227121335-0a58434b36f2 h1:co1YnJJ6rDvcodJzcXObchJMfHclIROMulsWObuNfTY=
-github.com/smallnest/ringbuffer v0.0.0-20210227121335-0a58434b36f2/go.mod h1:mXcZNMJHswhQDDJZIjdtJoG97JIwIa/HdcHNM3w15T0=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/csrf v1.6.0/go.mod h1:7tSf8kmjNYr7IWDCYhd3U8Ck34iQ/Yw5CJu7bAkHEGI=
@@ -139,6 +141,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/smallnest/ringbuffer v0.0.0-20210227121335-0a58434b36f2 h1:co1YnJJ6rDvcodJzcXObchJMfHclIROMulsWObuNfTY=
+github.com/smallnest/ringbuffer v0.0.0-20210227121335-0a58434b36f2/go.mod h1:mXcZNMJHswhQDDJZIjdtJoG97JIwIa/HdcHNM3w15T0=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/internal/proto/clientmsg.go
+++ b/internal/proto/clientmsg.go
@@ -18,6 +18,7 @@ type ClientResizeHeader struct {
 // ClientStartHeader specifies a request to start command
 type ClientStartHeader struct {
 	Type    string  `json:"type"`
+	ID      string  `json:"id"`
 	Command Command `json:"command"`
 }
 

--- a/server.go
+++ b/server.go
@@ -201,6 +201,9 @@ func Serve(ctx context.Context, c *websocket.Conn, execer Execer, options *Optio
 				go func() {
 					for {
 						select {
+						// Stop looping once this request finishes.
+						case <-ctx.Done():
+							return
 						case <-heartbeat.C:
 						}
 						rprocess.timeout.Reset(options.ReconnectingProcessTimeout)

--- a/server.go
+++ b/server.go
@@ -7,6 +7,11 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/smallnest/ringbuffer"
 
 	"go.coder.com/flog"
 	"golang.org/x/sync/errgroup"
@@ -16,12 +21,26 @@ import (
 	"cdr.dev/wsep/internal/proto"
 )
 
+var reconnectingProcesses sync.Map
+
+// Options allows configuring the server.
+type Options struct {
+	ReconnectingProcessTimeout time.Duration
+}
+
 // Serve runs the server-side of wsep.
 // The execer may be another wsep connection for chaining.
 // Use LocalExecer for local command execution.
-func Serve(ctx context.Context, c *websocket.Conn, execer Execer) error {
-	ctx, cancel := context.WithCancel(ctx)
+func Serve(pctx context.Context, c *websocket.Conn, execer Execer, options *Options) error {
+	ctx, cancel := context.WithCancel(pctx)
 	defer cancel()
+
+	if options == nil {
+		options = &Options{}
+	}
+	if options.ReconnectingProcessTimeout == 0 {
+		options.ReconnectingProcessTimeout = 5 * time.Minute
+	}
 
 	c.SetReadLimit(maxMessageSize)
 	var (
@@ -29,11 +48,6 @@ func Serve(ctx context.Context, c *websocket.Conn, execer Execer) error {
 		process   Process
 		wsNetConn = websocket.NetConn(ctx, c, websocket.MessageBinary)
 	)
-	defer func() {
-		if process != nil {
-			process.Close()
-		}
-	}()
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -61,36 +75,142 @@ func Serve(ctx context.Context, c *websocket.Conn, execer Execer) error {
 
 		switch header.Type {
 		case proto.TypeStart:
+			if process != nil {
+				return errors.New("command already started")
+			}
+
 			var header proto.ClientStartHeader
 			err = json.Unmarshal(byt, &header)
 			if err != nil {
 				return xerrors.Errorf("unmarshal start header: %w", err)
 			}
-			process, err = execer.Start(ctx, mapToClientCmd(header.Command))
-			if err != nil {
-				return err
-			}
 
-			_ = sendPID(ctx, process.Pid(), wsNetConn)
+			command := mapToClientCmd(header.Command)
 
-			var outputgroup errgroup.Group
-			outputgroup.Go(func() error {
-				return copyWithHeader(process.Stdout(), wsNetConn, proto.Header{Type: proto.TypeStdout})
-			})
-			outputgroup.Go(func() error {
-				return copyWithHeader(process.Stderr(), wsNetConn, proto.Header{Type: proto.TypeStderr})
-			})
-
-			go func() {
-				defer wsNetConn.Close()
-				_ = outputgroup.Wait()
-				err = process.Wait()
-				if exitErr, ok := err.(ExitError); ok {
-					_ = sendExitCode(ctx, exitErr.Code, wsNetConn)
-					return
+			// Only allow TTYs with IDs to be reconnected.
+			if command.TTY && header.ID != "" {
+				// Enforce a consistent format for IDs.
+				_, err := uuid.Parse(header.ID)
+				if err != nil {
+					flog.Error("%s is not a valid uuid: %w", header.ID, err)
 				}
-				_ = sendExitCode(ctx, 0, wsNetConn)
-			}()
+
+				// Get an existing process or create a new one.
+				var rprocess *reconnectingProcess
+				rawRProcess, ok := reconnectingProcesses.Load(header.ID)
+				if ok {
+					rprocess, ok = rawRProcess.(*reconnectingProcess)
+					if !ok {
+						flog.Error("found invalid type in reconnecting process map for ID %s", header.ID)
+					}
+					process = rprocess.process
+				} else {
+					process, err = execer.Start(ctx, command)
+					if err != nil {
+						return err
+					}
+
+					rprocess = &reconnectingProcess{
+						activeConns: make(map[string]net.Conn),
+						process:     process,
+						timeout:     time.NewTimer(options.ReconnectingProcessTimeout),
+						// Default to buffer 1MB.
+						ringBuffer: ringbuffer.New(1 << 20),
+					}
+					reconnectingProcesses.Store(header.ID, rprocess)
+					go func() {
+						// Close if the inactive timeout occurs, or the context ends.
+						select {
+						case <-rprocess.timeout.C:
+							flog.Info("killing reconnecting process %s due to inactivity", header.ID)
+						case <-pctx.Done():
+						}
+						rprocess.Close()
+					}()
+					go func() {
+						buffer := make([]byte, 32*1024)
+						for {
+							// TODO: This is erroring with "read /dev/ptmx: input/output
+							// error" when the web socket closes causing reconnection to stop
+							// working.
+							read, err := rprocess.process.Stdout().Read(buffer)
+							if err != nil {
+								flog.Error("reconnecting process %s read: %v", header.ID, err)
+								break
+							}
+							part := buffer[:read]
+							_, err = rprocess.ringBuffer.Write(part)
+							if err != nil {
+								flog.Error("reconnecting process %s write buffer: %v", header.ID, err)
+								break
+							}
+							rprocess.activeConnsMutex.Lock()
+							for _, conn := range rprocess.activeConns {
+								_ = sendOutput(ctx, part, conn)
+							}
+							rprocess.activeConnsMutex.Unlock()
+						}
+						// If we break from the loop, the reconnecting PTY ended or errored.
+						rprocess.Close()
+						reconnectingProcesses.Delete(header.ID)
+					}()
+				}
+
+				err = sendPID(ctx, process.Pid(), wsNetConn)
+				if err != nil {
+					flog.Error("failed to send pid %d", process.Pid())
+				}
+
+				// Write the initial contents out.
+				err = sendOutput(ctx, rprocess.ringBuffer.Bytes(), wsNetConn)
+				if err != nil {
+					return xerrors.Errorf("write reconnecting process %s buffer: %w", header.ID, err)
+				}
+
+				connectionID := uuid.NewString()
+				rprocess.activeConnsMutex.Lock()
+				rprocess.activeConns[connectionID] = wsNetConn
+				rprocess.activeConnsMutex.Unlock()
+				defer func() {
+					wsNetConn.Close()
+					rprocess.activeConnsMutex.Lock()
+					delete(rprocess.activeConns, connectionID)
+					rprocess.activeConnsMutex.Unlock()
+				}()
+			} else {
+				process, err = execer.Start(ctx, command)
+				if err != nil {
+					return err
+				}
+
+				err = sendPID(ctx, process.Pid(), wsNetConn)
+				if err != nil {
+					flog.Error("failed to send pid %d", process.Pid())
+				}
+
+				var outputgroup errgroup.Group
+				outputgroup.Go(func() error {
+					return copyWithHeader(process.Stdout(), wsNetConn, proto.Header{Type: proto.TypeStdout})
+				})
+				outputgroup.Go(func() error {
+					return copyWithHeader(process.Stderr(), wsNetConn, proto.Header{Type: proto.TypeStderr})
+				})
+
+				go func() {
+					defer wsNetConn.Close()
+					_ = outputgroup.Wait()
+					err = process.Wait()
+					if exitErr, ok := err.(ExitError); ok {
+						_ = sendExitCode(ctx, exitErr.Code, wsNetConn)
+						return
+					}
+					_ = sendExitCode(ctx, 0, wsNetConn)
+				}()
+
+				defer func() {
+					process.Close()
+				}()
+			}
 		case proto.TypeResize:
 			if process == nil {
 				return errors.New("resize sent before command started")
@@ -143,6 +263,15 @@ func sendPID(_ context.Context, pid int, conn net.Conn) error {
 	return err
 }
 
+func sendOutput(_ context.Context, data []byte, conn net.Conn) error {
+	header, err := json.Marshal(proto.ServerPidHeader{Type: proto.TypeStdout})
+	if err != nil {
+		return err
+	}
+	_, err = proto.WithHeader(conn, header).Write(data)
+	return err
+}
+
 func copyWithHeader(r io.Reader, w io.Writer, header proto.Header) error {
 	headerByt, err := json.Marshal(header)
 	if err != nil {
@@ -154,4 +283,23 @@ func copyWithHeader(r io.Reader, w io.Writer, header proto.Header) error {
 		return err
 	}
 	return nil
+}
+
+type reconnectingProcess struct {
+	activeConnsMutex sync.Mutex
+	activeConns      map[string]net.Conn
+
+	ringBuffer *ringbuffer.RingBuffer
+	timeout    *time.Timer
+	process    Process
+}
+
+func (r *reconnectingProcess) Close() {
+	r.activeConnsMutex.Lock()
+	defer r.activeConnsMutex.Unlock()
+	for _, conn := range r.activeConns {
+		_ = conn.Close()
+	}
+	_ = r.process.Close()
+	r.ringBuffer.Reset()
 }

--- a/server.go
+++ b/server.go
@@ -196,7 +196,7 @@ func Serve(ctx context.Context, c *websocket.Conn, execer Execer, options *Optio
 
 				// Keep resetting the inactivity timer while this connection is alive.
 				rprocess.timeout.Reset(options.ReconnectingProcessTimeout)
-				heartbeat := time.NewTimer(options.ReconnectingProcessTimeout / 2)
+				heartbeat := time.NewTicker(options.ReconnectingProcessTimeout / 2)
 				defer heartbeat.Stop()
 				go func() {
 					for {

--- a/tty_test.go
+++ b/tty_test.go
@@ -135,7 +135,9 @@ func TestReconnectTTY(t *testing.T) {
 
 	// Test disconnecting while another connection is active.
 	ws2, server2 := mockConn(ctx, t, &Options{
-		ReconnectingProcessTimeout: time.Second,
+		// Divide the time to test that the heartbeat keeps it open through multiple
+		// intervals.
+		ReconnectingProcessTimeout: time.Second / 4,
 	})
 	defer server2.Close()
 

--- a/tty_test.go
+++ b/tty_test.go
@@ -109,8 +109,7 @@ func TestReconnectTTY(t *testing.T) {
 
 	assert.True(t, "find echo", findEcho(expected))
 
-	// Test disconnecting (which starts inactivity) then reconnecting (which
-	// cancels it).
+	// Test disconnecting then reconnecting.
 	ws.Close(websocket.StatusNormalClosure, "disconnected")
 	server.Close()
 
@@ -134,10 +133,9 @@ func TestReconnectTTY(t *testing.T) {
 
 	assert.True(t, "find echo", findEcho(expected))
 
-	// Test disconnecting while another connection is active (which should skip
-	// starting inactivity entirely).
+	// Test disconnecting while another connection is active.
 	ws2, server2 := mockConn(ctx, t, &Options{
-		ReconnectingProcessTimeout: time.Millisecond,
+		ReconnectingProcessTimeout: time.Second,
 	})
 	defer server2.Close()
 


### PR DESCRIPTION
I tried to slot this in without disturbing the existing code too much although I think it came out a bit wonky in places because of that.  For example I wonder if reconnect should be a separate message since it seems odd that you can specify the ID of one command then pass a different arguments which will be ignored if the command with that ID is already running.  But having one message does make things convenient.