### PR TITLE
Fix remoteProcess race between Close and Read

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,6 +38,9 @@ type Command struct {
 	WorkingDir string
 }
 
+// Start runs the command on the remote.  Once a command is started, callers should
+// not read from, write to, or close the websocket.  Closing the returned Process will
+// also close the websocket.
 func (r remoteExec) Start(ctx context.Context, c Command) (Process, error) {
 	header := proto.ClientStartHeader{
 		ID:      c.ID,

--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package wsep
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -85,7 +86,7 @@ func TestRemoteExec(t *testing.T) {
 	testExecer(ctx, t, execer)
 }
 
-func TestRemoveClose(t *testing.T) {
+func TestRemoteClose(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -108,10 +109,14 @@ func TestRemoveClose(t *testing.T) {
 	i := proc.Stdin()
 	o := proc.Stdout()
 	buf := make([]byte, 2048)
-	_, err = i.Write([]byte("echo foo"))
+	echoMsgBldr := strings.Builder{}
+	for i := 0; i < 512; i++ {
+		echoMsgBldr.WriteString("g")
+	}
+	_, err = fmt.Fprintf(i, "echo '%s'\r\n", echoMsgBldr.String())
 	assert.Success(t, "echo", err)
 	bldr := strings.Builder{}
-	for !strings.Contains(bldr.String(), "foo") {
+	for !strings.Contains(bldr.String(), echoMsgBldr.String()) {
 		n, err := o.Read(buf)
 		if xerrors.Is(err, io.EOF) {
 			break
@@ -123,6 +128,7 @@ func TestRemoveClose(t *testing.T) {
 	err = proc.Close()
 	assert.Success(t, "close proc", err)
 	// note that proc.Close() also closes the websocket.
+	assert.Success(t, "context", ctx.Err())
 }
 
 func TestRemoteExecFail(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -193,7 +193,7 @@ func TestRemoteClosePartialRead(t *testing.T) {
 	n, err := o.Read(buf)
 	assert.Success(t, "read", err)
 	assert.Equal(t, "read 2 bytes", 2, n)
-	
+
 	err = proc.Close()
 	assert.Success(t, "close proc", err)
 	// note that proc.Close() also closes the websocket.

--- a/tty_test.go
+++ b/tty_test.go
@@ -168,7 +168,6 @@ func TestReconnectTTY(t *testing.T) {
 	assert.Success(t, "context", ctx.Err())
 }
 
-
 func findEcho(t *testing.T, process Process, expected []string, notExpected ...string) bool {
 	scanner := bufio.NewScanner(process.Stdout())
 outer:

--- a/tty_test.go
+++ b/tty_test.go
@@ -69,10 +69,10 @@ func TestReconnectTTY(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	ws, server := mockConn(ctx, t, &Options{
+	ws1, server1 := mockConn(ctx, t, &Options{
 		ReconnectingProcessTimeout: time.Second,
 	})
-	defer server.Close()
+	defer server1.Close()
 
 	command := Command{
 		ID:      uuid.NewString(),
@@ -80,46 +80,30 @@ func TestReconnectTTY(t *testing.T) {
 		TTY:     true,
 		Stdin:   true,
 	}
-	execer := RemoteExecer(ws)
-	process, err := execer.Start(ctx, command)
+	execer1 := RemoteExecer(ws1)
+	process1, err := execer1.Start(ctx, command)
 	assert.Success(t, "start sh", err)
 
 	// Write some unique output.
 	echoCmd := "echo test:$((1+1))"
 	data := []byte(echoCmd + "\r\n")
-	_, err = process.Stdin().Write(data)
+	_, err = process1.Stdin().Write(data)
 	assert.Success(t, "write to stdin", err)
 	expected := []string{echoCmd, "test:2"}
 
-	findEcho := func(expected []string) bool {
-		scanner := bufio.NewScanner(process.Stdout())
-	outer:
-		for _, str := range expected {
-			for scanner.Scan() {
-				line := scanner.Text()
-				t.Logf("bash tty stdout = %s", line)
-				if strings.Contains(line, str) {
-					continue outer
-				}
-			}
-			return false // Reached the end of output without finding str.
-		}
-		return true
-	}
-
-	assert.True(t, "find echo", findEcho(expected))
+	assert.True(t, "find echo", findEcho(t, process1, expected))
 
 	// Test disconnecting then reconnecting.
-	ws.Close(websocket.StatusNormalClosure, "disconnected")
-	server.Close()
+	process1.Close()
+	server1.Close()
 
-	ws, server = mockConn(ctx, t, &Options{
+	ws2, server2 := mockConn(ctx, t, &Options{
 		ReconnectingProcessTimeout: time.Second,
 	})
-	defer server.Close()
+	defer server2.Close()
 
-	execer = RemoteExecer(ws)
-	process, err = execer.Start(ctx, command)
+	execer2 := RemoteExecer(ws2)
+	process2, err := execer2.Start(ctx, command)
 	assert.Success(t, "attach sh", err)
 
 	// The inactivity timeout should not have been triggered.
@@ -127,52 +111,81 @@ func TestReconnectTTY(t *testing.T) {
 
 	echoCmd = "echo test:$((2+2))"
 	data = []byte(echoCmd + "\r\n")
-	_, err = process.Stdin().Write(data)
+	_, err = process2.Stdin().Write(data)
 	assert.Success(t, "write to stdin", err)
 	expected = append(expected, echoCmd, "test:4")
 
-	assert.True(t, "find echo", findEcho(expected))
+	assert.True(t, "find echo", findEcho(t, process2, expected))
 
 	// Test disconnecting while another connection is active.
-	ws2, server2 := mockConn(ctx, t, &Options{
+	ws3, server3 := mockConn(ctx, t, &Options{
 		// Divide the time to test that the heartbeat keeps it open through multiple
 		// intervals.
 		ReconnectingProcessTimeout: time.Second / 4,
 	})
-	defer server2.Close()
+	defer server3.Close()
 
-	execer = RemoteExecer(ws2)
-	process, err = execer.Start(ctx, command)
+	execer3 := RemoteExecer(ws3)
+	process3, err := execer3.Start(ctx, command)
 	assert.Success(t, "attach sh", err)
 
-	ws.Close(websocket.StatusNormalClosure, "disconnected")
-	server.Close()
+	process2.Close()
+	server2.Close()
 	time.Sleep(time.Second)
 
 	// This connection should still be up.
 	echoCmd = "echo test:$((3+3))"
 	data = []byte(echoCmd + "\r\n")
-	_, err = process.Stdin().Write(data)
+	_, err = process3.Stdin().Write(data)
 	assert.Success(t, "write to stdin", err)
 	expected = append(expected, echoCmd, "test:6")
 
-	assert.True(t, "find echo", findEcho(expected))
+	assert.True(t, "find echo", findEcho(t, process3, expected))
 
 	// Close the remaining connection and wait for inactivity.
-	ws2.Close(websocket.StatusNormalClosure, "disconnected")
-	server2.Close()
+	process3.Close()
+	server3.Close()
 	time.Sleep(time.Second)
 
 	// The next connection should start a new process.
-	ws, server = mockConn(ctx, t, &Options{
+	ws4, server4 := mockConn(ctx, t, &Options{
 		ReconnectingProcessTimeout: time.Second,
 	})
-	defer server.Close()
+	defer server4.Close()
 
-	execer = RemoteExecer(ws)
-	process, err = execer.Start(ctx, command)
+	execer4 := RemoteExecer(ws4)
+	process4, err := execer4.Start(ctx, command)
 	assert.Success(t, "attach sh", err)
 
 	// This time no echo since it is a new process.
-	assert.True(t, "find echo", !findEcho(expected))
+	notExpected := expected
+	echoCmd = "echo done"
+	data = []byte(echoCmd + "\r\n")
+	_, err = process4.Stdin().Write(data)
+	assert.Success(t, "write to stdin", err)
+	expected = []string{echoCmd, "done"}
+	assert.True(t, "find echo", findEcho(t, process4, expected, notExpected...))
+	assert.Success(t, "context", ctx.Err())
+}
+
+
+func findEcho(t *testing.T, process Process, expected []string, notExpected ...string) bool {
+	scanner := bufio.NewScanner(process.Stdout())
+outer:
+	for _, str := range expected {
+		for scanner.Scan() {
+			line := scanner.Text()
+			t.Logf("bash tty stdout = %s", line)
+			for _, bad := range notExpected {
+				if strings.Contains(line, bad) {
+					return false
+				}
+			}
+			if strings.Contains(line, str) {
+				continue outer
+			}
+		}
+		return false // Reached the end of output without finding str.
+	}
+	return true
 }


### PR DESCRIPTION
Fixes the underlying cause of https://github.com/coder/v1/issues/13308

It doesn't appear to be safe to call Read and Close on a websockets concurrently from different threads.

Read reads data from the network, but doesn't hold the read mutex for the entire time it is reading a message. In particular, it releases the mutex after reading the websocket frame header, then reacquires it to read the rest of the frame. Close sends a close frame and then reads until it gets a close frame in response, but in the window open during the call to Read, it could read the payload of a previous frame when it expects to get a websocket header.