### PR TITLE
Fix attach resize

### DIFF
--- a/dev/client/main.go
+++ b/dev/client/main.go
@@ -70,7 +70,7 @@ func do(fl *pflag.FlagSet, tty bool, id string, timeout time.Duration) {
 	if err != nil {
 		flog.Fatal("failed to dial remote executor: %v", err)
 	}
-	defer conn.Close(websocket.StatusAbnormalClosure, "terminate process")
+	defer conn.Close(websocket.StatusNormalClosure, "terminate process")
 
 	executor := wsep.RemoteExecer(conn)
 

--- a/dev/server/main.go
+++ b/dev/server/main.go
@@ -29,7 +29,7 @@ func serve(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		flog.Error("failed to serve execer: %v", err)
-		ws.Close(websocket.StatusAbnormalClosure, "failed to serve execer")
+		ws.Close(websocket.StatusInternalError, "failed to serve execer")
 		return
 	}
 	ws.Close(websocket.StatusNormalClosure, "normal closure")

--- a/server.go
+++ b/server.go
@@ -69,7 +69,7 @@ func (srv *Server) SessionCount() int {
 func (srv *Server) Close() {
 	srv.sessions.Range(func(k, rawSession interface{}) bool {
 		if s, ok := rawSession.(*Session); ok {
-			s.Close()
+			s.Close("test cleanup")
 		}
 		return true
 	})

--- a/session.go
+++ b/session.go
@@ -357,7 +357,7 @@ func (s *Session) waitForStateOrContext(ctx context.Context, state State) {
 
 // captureStdout captures the first line of stdout.  Screen emits errors to
 // stdout so this allows logging extra context beyond the exit code.
-func captureStdout(process Process) chan string {
+func captureStdout(process Process) <-chan string {
 	stdout := make(chan string, 1)
 	go func() {
 		scanner := bufio.NewScanner(process.Stdout())

--- a/session.go
+++ b/session.go
@@ -150,10 +150,12 @@ func (s *Session) sendCommand(ctx context.Context, command string, successErrors
 		if ctx.Err() != nil {
 			return true, ctx.Err()
 		}
-		details := <-stdout
-		for _, se := range successErrors {
-			if strings.Contains(details, se) {
-				return true, nil
+		if err != nil {
+			details := <-stdout
+			for _, se := range successErrors {
+				if strings.Contains(details, se) {
+					return true, nil
+				}
 			}
 		}
 		// Sometimes a command will fail without any error output whatsoever but

--- a/session.go
+++ b/session.go
@@ -170,8 +170,8 @@ func (s *Session) sendCommand(ctx context.Context, command string) error {
 	}
 }
 
-// Attach waits for the session to become attachable and returns a command that
-// can be used to attach to the session.
+// Attach attaches to the session, waits for the attach to complete, then
+// returns the attached process.
 func (s *Session) Attach(ctx context.Context) (Process, error) {
 	// We need to do this while behind the mutex to ensure another attach does not
 	// come in and spawn a duplicate session.

--- a/session.go
+++ b/session.go
@@ -104,18 +104,16 @@ func (s *Session) lifecycle() {
 	// enough for the first screen attach to be able to start up the daemon.
 	s.timer = time.AfterFunc(s.attachTimeout, s.Close)
 
+	s.setState(StateReady, nil)
+
 	// Handle the close event by asking screen to quit the session.  We have no
 	// way of knowing when the daemon process dies so the Go side will not get
 	// cleaned up until the timeout if the process gets killed externally (for
 	// example via `exit`).
-	go func() {
-		s.waitForState(StateClosing)
-		s.timer.Stop()
-		err := s.sendCommand(context.Background(), "quit")
-		s.setState(StateDone, err)
-	}()
-
-	s.setState(StateReady, nil)
+	s.waitForState(StateClosing)
+	s.timer.Stop()
+	err = s.sendCommand(context.Background(), "quit")
+	s.setState(StateDone, err)
 }
 
 // sendCommand runs a screen command against a session.  If the command is quit

--- a/session.go
+++ b/session.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.coder.com/flog"
 	"golang.org/x/xerrors"
 )
 
@@ -115,6 +116,9 @@ func (s *Session) lifecycle() {
 	s.timer.Stop()
 	// If the command errors that the session is already gone that is fine.
 	err = s.sendCommand(context.Background(), "quit", []string{"No screen session found"})
+	if err != nil {
+		flog.Error("failed to kill session %s: %v", s.id, err)
+	}
 	s.setState(StateDone, err)
 }
 

--- a/session.go
+++ b/session.go
@@ -261,6 +261,13 @@ func (s *Session) heartbeat(ctx context.Context) {
 			return
 		case <-heartbeat.C:
 		}
+		// The goroutine that cancels the heartbeat on a close state change might
+		// not run before the next heartbeat which means the heartbeat will start
+		// the timer again.
+		state, _ := s.WaitForState(StateReady)
+		if state > StateReady {
+			return
+		}
 		s.timer.Reset(s.options.SessionTimeout)
 	}
 }

--- a/session.go
+++ b/session.go
@@ -33,8 +33,6 @@ const (
 
 // Session represents a `screen` session.
 type Session struct {
-	// attachTimeout is how long to wait for an attach or command.
-	attachTimeout time.Duration
 	// command is the original command used to spawn the session.
 	command *Command
 	// cond broadcasts session changes and any accompanying errors.

--- a/tty_test.go
+++ b/tty_test.go
@@ -146,7 +146,7 @@ func TestReconnectTTY(t *testing.T) {
 
 		// Try connecting a bunch of sessions at once.
 		var wg sync.WaitGroup
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 10; i++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/tty_test.go
+++ b/tty_test.go
@@ -180,7 +180,7 @@ func newServer(t *testing.T) *Server {
 // newSession returns a command for starting/attaching to a session with a
 // context for timing out.
 func newSession(t *testing.T) (context.Context, Command) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 
 	command := Command{


### PR DESCRIPTION
Previously we would spawn the daemon via -Dm then attach with -x once it
was ready.  This had a flaw: the daemon starts with a hardcoded 24x80
size and when the attach comes in it resizes and leaves a bunch of
confusing whitespace above your prompt.

Now we skip the daemon spawn and go straight for the attach but with the
addition of -RR which lets screen spawn the daemon for us if it does
not yet exist.

Consequences:

1. We can only allow one attach at a time because screen has no problem
   creating multiple daemons with the same name.
2. IDs cannot overlap since screen will do partial matching when we do
   not include the PID which we no longer have.
3. We do not know when the daemon exits so cleanup only happens on the
   timeout.
4. We have to kill the session by sending the quit command through
   screen.  When we do this it is possible the session is already dead.
5. If the daemon exits and the user reconnects before the timeout the
   daemon will be respawned all while the Go program remains blissfully
   unaware assuming it has been up this whole time.  Does not change
   anything in practice, just a bit different in terms of underlying
   architecture.

In some ways this new architecture is actually simpler with roughly the
same functionality but it does not support concurrent attaches and theoretically
has a greater danger of desyncing from screen's own state (although at the
moment nothing concretely dangerous comes to mind).