### PR TITLE
fix: Command: default rows and cols if set to 0

### DIFF
--- a/server.go
+++ b/server.go
@@ -19,6 +19,11 @@ import (
 	"cdr.dev/wsep/internal/proto"
 )
 
+const (
+	defaultRows = 80
+	defaultCols = 24
+)
+
 // Options allows configuring the server.
 type Options struct {
 	SessionTimeout time.Duration
@@ -138,9 +143,14 @@ func (srv *Server) Serve(ctx context.Context, c *websocket.Conn, execer Execer, 
 			command := mapToClientCmd(header.Command)
 
 			if command.TTY {
-				// Enforce rows and columns so the TTY will be correctly sized.
-				if command.Rows == 0 || command.Cols == 0 {
-					return xerrors.Errorf("rows and cols must be non-zero")
+				// If rows and cols are not provided, default to 80x24.
+				if command.Rows == 0 {
+					flog.Info("rows not provided, defaulting to 80")
+					command.Rows = defaultRows
+				}
+				if command.Cols == 0 {
+					flog.Info("cols not provided, defaulting to 24")
+					command.Cols = defaultCols
 				}
 			}
 

--- a/tty_test.go
+++ b/tty_test.go
@@ -39,7 +39,13 @@ func TestReconnectTTY(t *testing.T) {
 		server := newServer(t)
 		ctx, command := newSession(t)
 		command.Rows = 0
-		connect(ctx, t, command, server, nil, "rows and cols must be non-zero")
+		command.Cols = 0
+		ps1, _ := connect(ctx, t, command, server, nil, "")
+		expected := writeUnique(t, ps1)
+		assert.True(t, "find initial output", checkStdout(t, ps1, expected, []string{}))
+
+		ps2, _ := connect(ctx, t, command, server, nil, "")
+		assert.True(t, "find reconnected output", checkStdout(t, ps2, expected, []string{}))
 	})
 
 	t.Run("DeprecatedServe", func(t *testing.T) {
@@ -188,8 +194,8 @@ func newSession(t *testing.T) (context.Context, Command) {
 		Command: "sh",
 		TTY:     true,
 		Stdin:   true,
-		Cols:    100,
-		Rows:    100,
+		Cols:    defaultCols,
+		Rows:    defaultRows,
 		Env:     []string{"TERM=xterm"},
 	}
 


### PR DESCRIPTION
Default `Command.Rows` or `Command.Cols` if set to 0 instead of bailing with an error.